### PR TITLE
バージョン定数をexportする

### DIFF
--- a/etc/aiscript.api.md
+++ b/etc/aiscript.api.md
@@ -23,6 +23,9 @@ type AddAssign_2 = NodeBase_2 & {
 };
 
 // @public (undocumented)
+export const AISCRIPT_VERSION: "0.16.0";
+
+// @public (undocumented)
 abstract class AiScriptError extends Error {
     constructor(message: string, info?: any);
     // (undocumented)

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -1,6 +1,6 @@
 <template>
 <div id="root">
-	<h1>AiScript (v{{ std['Core:v'].value }}) Playground</h1>
+	<h1>AiScript (v{{ AISCRIPT_VERSION }}) Playground</h1>
 	<div id="grid1">
 		<div id="editor" class="container">
 			<header>Input<div class="actions"><button @click="setCode">FizzBuzz</button></div></header>
@@ -42,7 +42,7 @@
 
 <script setup>
 import { ref, watch } from 'vue';
-import { Interpreter, Parser, utils } from '@syuilo/aiscript';
+import { AISCRIPT_VERSION, Interpreter, Parser, utils } from '@syuilo/aiscript';
 import { std } from '@syuilo/aiscript/interpreter/lib/std';
 
 import { PrismEditor } from 'vue-prism-editor';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const AISCRIPT_VERSION = '0.16.0' as const; // TODO: package.jsonを参照
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,4 @@ export { PluginType };
 export { Cst };
 export { errors };
 export { Ast };
-export const AISCRIPT_VERSION = '0.16.0' as const;
+export const AISCRIPT_VERSION = '0.16.0' as const; // TODO: package.jsonを参照

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,4 @@ export { PluginType };
 export { Cst };
 export { errors };
 export { Ast };
-export const AISCRIPT_VERSION = '0.16.0';
+export const AISCRIPT_VERSION = '0.16.0' as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,4 @@ export { PluginType };
 export { Cst };
 export { errors };
 export { Ast };
+export const AISCRIPT_VERSION = '0.16.0';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { Parser, ParserPlugin, PluginType } from './parser/index.js';
 import * as Cst from './parser/node.js';
 import * as errors from './error.js';
 import * as Ast from './node.js';
+import { AISCRIPT_VERSION } from './constants.js'
 export { Interpreter };
 export { Scope };
 export { utils };
@@ -20,4 +21,4 @@ export { PluginType };
 export { Cst };
 export { errors };
 export { Ast };
-export const AISCRIPT_VERSION = '0.16.0' as const; // TODO: package.jsonを参照
+export { AISCRIPT_VERSION };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { Parser, ParserPlugin, PluginType } from './parser/index.js';
 import * as Cst from './parser/node.js';
 import * as errors from './error.js';
 import * as Ast from './node.js';
-import { AISCRIPT_VERSION } from './constants.js'
+import { AISCRIPT_VERSION } from './constants.js';
 export { Interpreter };
 export { Scope };
 export { utils };

--- a/src/interpreter/lib/std.ts
+++ b/src/interpreter/lib/std.ts
@@ -3,8 +3,8 @@ import { v4 as uuid } from 'uuid';
 import seedrandom from 'seedrandom';
 import { NUM, STR, FN_NATIVE, FALSE, TRUE, ARR, NULL, BOOL, OBJ, ERROR } from '../value.js';
 import { assertNumber, assertString, assertBoolean, valToJs, jsToVal, assertFunction, assertObject, eq, expectAny, assertArray, reprValue } from '../util.js';
-import { AISCRIPT_VERSION } from '../../index.js';
 import { AiScriptRuntimeError } from '../../error.js';
+import { AISCRIPT_VERSION } from '../../constants.js'
 import type { Value } from '../value.js';
 
 export const std: Record<string, Value> = {

--- a/src/interpreter/lib/std.ts
+++ b/src/interpreter/lib/std.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import seedrandom from 'seedrandom';
 import { NUM, STR, FN_NATIVE, FALSE, TRUE, ARR, NULL, BOOL, OBJ, ERROR } from '../value.js';
 import { assertNumber, assertString, assertBoolean, valToJs, jsToVal, assertFunction, assertObject, eq, expectAny, assertArray, reprValue } from '../util.js';
+import { AISCRIPT_VERSION } from '../../index.js';
 import { AiScriptRuntimeError } from '../../error.js';
 import type { Value } from '../value.js';
 
@@ -10,7 +11,7 @@ export const std: Record<string, Value> = {
 	'help': STR('SEE: https://github.com/syuilo/aiscript/blob/master/docs/get-started.md'),
 
 	//#region Core
-	'Core:v': STR('0.16.0'), // TODO: package.jsonを参照
+	'Core:v': STR(AISCRIPT_VERSION),
 
 	'Core:ai': STR('kawaii'),
 

--- a/src/interpreter/lib/std.ts
+++ b/src/interpreter/lib/std.ts
@@ -4,7 +4,7 @@ import seedrandom from 'seedrandom';
 import { NUM, STR, FN_NATIVE, FALSE, TRUE, ARR, NULL, BOOL, OBJ, ERROR } from '../value.js';
 import { assertNumber, assertString, assertBoolean, valToJs, jsToVal, assertFunction, assertObject, eq, expectAny, assertArray, reprValue } from '../util.js';
 import { AiScriptRuntimeError } from '../../error.js';
-import { AISCRIPT_VERSION } from '../../constants.js'
+import { AISCRIPT_VERSION } from '../../constants.js';
 import type { Value } from '../value.js';
 
 export const std: Record<string, Value> = {


### PR DESCRIPTION
例えば使用中のバージョンを表示したり、コードのバージョンアノテーションと比較したりするのにバージョン定数がexportされていると便利だと思われるので追加します。