### PR TITLE
最新版のビルド済みコードを提供するブランチを作る

### DIFF
--- a/.github/workflows/pre-built.yml
+++ b/.github/workflows/pre-built.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      BRANCH_NAME: built-${ GITHUB_REF##*/ }
 
     steps:
       - name: Checkout
@@ -38,6 +37,7 @@ jobs:
 
       - name: Deploy
         run: |
+          BRANCH_NAME=built-${GITHUB_REF##*/}
           cat .npmignore > .gitignore
           rm -rf .git
           git init -b $BRANCH_NAME

--- a/.github/workflows/pre-built.yml
+++ b/.github/workflows/pre-built.yml
@@ -1,0 +1,50 @@
+name: Deploy Pre-built branch
+
+on:
+  push:
+    branches:
+      - master
+      - aiscript-next
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BRANCH_NAME: built-${ GITHUB_REF##*/ }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 20.x
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy
+        run: |
+          cat .npmignore > .gitignore
+          rm -rf .git
+          git init -b $BRANCH_NAME
+          git config user.email "none"
+          git config user.name "bot"
+          git add .
+          git commit -m'update build'
+          git remote add origin $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+          gh auth setup-git
+          git push -f -u origin $BRANCH_NAME

--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,9 @@
 /src
 /test
 /coverage
+/.github
+/playground
+/temp
 .gitignore
 npm-debug.log
 gulpfile.js


### PR DESCRIPTION
master及びaiscript-nextの最新版をnpm等から利用出来るように、ビルド済のコードをgithub actionsで発行するようにします。
発行されたコードはbuilt-masterブランチとbuilt-aiscript-nextブランチにそれぞれ格納されます。
従って、package.jsonに以下のように記載すればnpmjs.comにpublishされたものとほぼ同様に使用できるようになります。
```package.json
{
  "dependencies": {
    "aiscript_master": "aiscript-dev/aiscript#built-master",
    "aiscript_next": "aiscript-dev/aiscript#built-aiscript-next"
  }
}
```

ついでに、.npmignoreにplaygroundとtempと.githubを追加しています。