### PR TITLE
npmに定期発行するworkflowを追加

### DIFF
--- a/.github/workflows/publish-daily-dev.yml
+++ b/.github/workflows/publish-daily-dev.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Check Commits
         run: |
-          echo 'LAST_COMMITS='$( git log --since yesterday | wc -c ) >> $GITHUB_ENV
+          echo 'LAST_COMMITS='$( git log --since '24 hours ago' | wc -c ) >> $GITHUB_ENV
 
       - name: Publish
         uses: JS-DevTools/npm-publish@v3

--- a/.github/workflows/publish-daily-dev.yml
+++ b/.github/workflows/publish-daily-dev.yml
@@ -1,0 +1,56 @@
+name: Daily Publication of branch master
+
+on:
+  schedule:
+    - cron:  '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      NPM_SECRET: ${{ secrets.NPM_SECRET }}
+      BRANCH: master
+      TAG: dev
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ env.BRANCH }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 20.x
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Set Version
+        run: |
+          TIME_STAMP=$( date +'%Y%m%d' )
+          VERSION_SUFFIX=-$TAG.$TIME_STAMP
+          vim package.json '+/"version"' '+s/:\s*".*\zs\ze"/'$VERSION_SUFFIX/ '+wq'
+
+      - name: Check Commits
+        run: |
+          echo 'LAST_COMMITS='$( git log --since yesterday | wc -c ) >> $GITHUB_ENV
+
+      - name: Publish
+        uses: JS-DevTools/npm-publish@v3
+        if: ${{ env.NPM_SECRET != '' && env.LAST_COMMITS != 0 }}
+        with:
+          token: ${{ env.NPM_SECRET }}
+          tag: ${{ env.TAG }}
+          access: public

--- a/.github/workflows/publish-daily-next.yml
+++ b/.github/workflows/publish-daily-next.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Check Commits
         run: |
-          echo 'LAST_COMMITS='$( git log --since yesterday | wc -c ) >> $GITHUB_ENV
+          echo 'LAST_COMMITS='$( git log --since '24 hours ago' | wc -c ) >> $GITHUB_ENV
 
       - name: Publish
         uses: JS-DevTools/npm-publish@v3

--- a/.github/workflows/publish-daily-next.yml
+++ b/.github/workflows/publish-daily-next.yml
@@ -1,0 +1,56 @@
+name: Daily Publication of branch aiscript-next
+
+on:
+  schedule:
+    - cron:  '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      NPM_SECRET: ${{ secrets.NPM_SECRET }}
+      BRANCH: aiscript-next
+      TAG: next
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ env.BRANCH }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 20.x
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Set Version
+        run: |
+          TIME_STAMP=$( date +'%Y%m%d' )
+          VERSION_SUFFIX=-$TAG.$TIME_STAMP
+          vim package.json '+/"version"' '+s/:\s*".*\zs\ze"/'$VERSION_SUFFIX/ '+wq'
+
+      - name: Check Commits
+        run: |
+          echo 'LAST_COMMITS='$( git log --since yesterday | wc -c ) >> $GITHUB_ENV
+
+      - name: Publish
+        uses: JS-DevTools/npm-publish@v3
+        if: ${{ env.NPM_SECRET != '' && env.LAST_COMMITS != 0 }}
+        with:
+          token: ${{ env.NPM_SECRET }}
+          tag: ${{ env.TAG }}
+          access: public

--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,9 @@
 /src
 /test
 /coverage
+/.github
+/playground
+/temp
 .gitignore
 npm-debug.log
 gulpfile.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@syuilo/aiscript",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@syuilo/aiscript",
-			"version": "0.16.0",
+			"version": "0.17.0",
 			"license": "MIT",
 			"dependencies": {
 				"seedrandom": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@syuilo/aiscript",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"description": "AiScript implementation",
 	"author": "syuilo <syuilotan@yahoo.co.jp>",
 	"license": "MIT",


### PR DESCRIPTION
## Why
#471

## What
毎日コミットの有無をチェックし、あればnpmにpublishするworkflowを追加します。
バージョニングはx.y.z-dev.YYYYMMDDです。

## 留意事項
- このworkflowではpackage.jsonに記載のバージョンに-dev.YYYYMMDDを単純に後置します。
  - semantic versioningの定義に従えば、バージョンx.y.z-dev.YYYYMMDDはバージョンx.y.zのプリリリースです。
  - すなわち、package.jsonに記載のバージョンは常に「次のバージョン」に保たれる必要があります。
- nextについては未テストです。