### PR TITLE
Chore: `vite.config.js`の`target`を`tsconfig.json`に合わせる

### DIFF
--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -10,4 +10,7 @@ export default defineConfig({
 			allow: [ '..' ]
 		}
 	},
+	build: {
+		target: "es2022"
+	},
 })

--- a/playground/vite.config.js
+++ b/playground/vite.config.js
@@ -1,5 +1,10 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { readFileSync } from 'fs';
+
+const data = JSON.parse(readFileSync('../tsconfig.json', 'utf8'));
+
+let target = data.compilerOptions.target;
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,6 +16,6 @@ export default defineConfig({
 		}
 	},
 	build: {
-		target: "es2022"
+		target: target
 	},
 })


### PR DESCRIPTION
# What

https://github.com/aiscript-dev/aiscript/blob/23764a69bd562df358b0d54977ec55a220a86584/tsconfig.json#L11
こう指定されているにも拘わらず、`playground`のViteでは`es2022`ではなく`es2019`が指定されていることが判明しました。
これにより、`tsconfig.json`との矛盾が生じていたので、`vite.config.js`から`tsconfig.json`の`compilerOptions.target`を読み込むことにより解消します。

# Why

#489 の解決で使用する予定の`BigInt`のリテラルが`playground`のビルドエラーの原因になっていました。
`aiscript`のビルドは動作していたのでviteを疑いました。

# Additional info (optional)

Node.jsやViteは素人なので、この方法が適切かどうかはわかりません。
御指南頂けますと幸いです。