### PR TITLE
分割代入

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - 関数`Str#charcode_at` `Str#to_arr` `Str#to_char_arr` `Str#to_charcode_arr` `Str#to_utf8_byte_arr` `Str#to_unicode_codepoint_arr` `Str:from_unicode_codepoints` `Str:from_utf8_bytes`を追加
 - Fix: `Str#codepoint_at`がサロゲートペアに対応していないのを修正
 - 配列の範囲外および非整数のインデックスへの代入でエラーを出すように
+- JavaScriptのように分割代入ができるように（現段階では機能は最小限）
 ## Note
 バージョン0.16.0に記録漏れがありました。
 >- 関数`Str:from_codepoint` `Str#codepoint_at`を追加

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -89,6 +89,46 @@ var func = null
 }
 ```
 
+### 代入
+宣言済みの変数の値を変更します。  
+```js
+var a = 0
+a = 1
+<: a // 1
+```
+```js
+// letで宣言された変数は代入不可
+let a = 0
+a = 1 // Runtime Error
+```
+
+#### 分割代入
+```js
+// 配列の分割代入
+var a = ''
+var b = ''
+[a, b] = ['hoge', 'fuga']
+<: a // 'hoge'
+<: b // 'fuga'
+// オブジェクトの分割代入
+{ name: a, nature: b } = { name: 'Ai-chan, nature: 'kawaii' }
+<: a // 'Ai-chan'
+<: b // 'kawaii'
+// 組み合わせ
+let ai_kun = {
+  name: 'Ai-kun',
+  nature: ['kakkoii', 'kawaii', 'ponkotsu'],
+}
+{ name: a, nature: [b] } = ai_kun
+<: a // 'Ai-kun'
+<: b // 'kakkoii'
+```
+```js
+// 代入値が分割できる型でなければエラー
+[a, b] = 1 // Runtime Error
+{ zero: a, one: b } = ['hoge', 'fuga'] // Runtime Error
+```
+
 ### for
 与えられた回数のループを行います。  
 ```js

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -111,7 +111,7 @@ var b = ''
 <: a // 'hoge'
 <: b // 'fuga'
 // オブジェクトの分割代入
-{ name: a, nature: b } = { name: 'Ai-chan, nature: 'kawaii' }
+{ name: a, nature: b } = { name: 'Ai-chan', nature: 'kawaii' }
 <: a // 'Ai-chan'
 <: b // 'kawaii'
 // 組み合わせ

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -627,6 +627,16 @@ export class Interpreter {
 			assertObject(assignee);
 
 			assignee.value.set(dest.name, value);
+		} else if (dest.type === 'arr') {
+			assertArray(value);
+			await Promise.all(dest.value.map(
+				(item, index) => this.assign(scope, item, value.value[index] ?? NULL)
+			));
+		} else if (dest.type === 'obj') {
+			assertObject(value);
+			await Promise.all([...dest.value].map(
+				([key, item]) => this.assign(scope, item, value.value.get(key) ?? NULL)
+			));
 		} else {
 			throw new AiScriptRuntimeError('The left-hand side of an assignment expression must be a variable or a property/index access.');
 		}

--- a/test/index.ts
+++ b/test/index.ts
@@ -2383,7 +2383,25 @@ describe('Variable declaration', () => {
 
 		assert.ok(err instanceof AiScriptRuntimeError);
 	});
-})
+});
+
+describe('Variable assignment', () => {
+	test.concurrent('simple', async () => {
+		eq(await exe(`
+			var hoge = 25
+			hoge = 7
+			<: hoge
+		`), NUM(7));
+	});
+	test.concurrent('destructuring assignment', async () => {
+		eq(await exe(`
+			var hoge = 'foo'
+			var fuga = { value: 'bar' }
+			[{ value: hoge }, fuga] = [fuga, hoge]
+			<: [hoge, fuga]
+		`), ARR([STR('bar'), STR('foo')]));
+	});
+});
 
 describe('primitive props', () => {
 	describe('num', () => {


### PR DESCRIPTION
#511 で言った分割代入がとりあえず形になったので申請します。
### 要改善？
まあいいやと思って申請しましたが、こうしたいという意見があれば直したいと思います。
- `[a, b] = [0]`のように要素が足りなかった時はNULLが代入されます。
- `[a, [b]] = [0]`のような場合には`Expected array, but got null.`のエラーが出ます。
- 変数宣言と同時に行うこと`let [a, b] = [0, 1]`はできません。