### PR TITLE
chore: bump version to 0.18.0

### DIFF
--- a/etc/aiscript.api.md
+++ b/etc/aiscript.api.md
@@ -23,7 +23,7 @@ type AddAssign_2 = NodeBase_2 & {
 };
 
 // @public (undocumented)
-export const AISCRIPT_VERSION: "0.17.0";
+export const AISCRIPT_VERSION: "0.18.0";
 
 // @public (undocumented)
 abstract class AiScriptError extends Error {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@syuilo/aiscript",
-	"version": "0.17.0",
+	"version": "0.18.0",
 	"description": "AiScript implementation",
 	"author": "syuilo <syuilotan@yahoo.co.jp>",
 	"license": "MIT",


### PR DESCRIPTION
次バージョンは0.18.0で問題ないと思うのでプリリリース発行用にアップデートします。