### PR TITLE
jestが落ちているのを修正

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -3163,7 +3163,7 @@ describe('std', () => {
 		test.concurrent('abort', async () => {
 			assert.rejects(
 				exe('Core:abort("hoge")'),
-				{ name: '', message: 'hoge' },
+				e => e.message.includes('hoge'),
 			);
 		});
 	});


### PR DESCRIPTION
#586 で言及したとおり、nextでインタプリタのエラーに行数をつけたことでCore:abortのテストが通らなくなっていたので修正します。