### PR TITLE
デフォルトではエラーハンドラ呼び出し時abortを行わないように

### DIFF
--- a/etc/aiscript.api.md
+++ b/etc/aiscript.api.md
@@ -572,6 +572,7 @@ export class Interpreter {
         err?(e: AiScriptError): void;
         log?(type: string, params: Record<string, any>): void;
         maxStep?: number;
+        failToAbort?: boolean;
     });
     // (undocumented)
     abort(): void;

--- a/etc/aiscript.api.md
+++ b/etc/aiscript.api.md
@@ -572,7 +572,7 @@ export class Interpreter {
         err?(e: AiScriptError): void;
         log?(type: string, params: Record<string, any>): void;
         maxStep?: number;
-        failToAbort?: boolean;
+        abortOnError?: boolean;
     });
     // (undocumented)
     abort(): void;

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -31,7 +31,7 @@ export class Interpreter {
 			err?(e: AiScriptError): void;
 			log?(type: string, params: Record<string, any>): void;
 			maxStep?: number;
-			failToAbort?: boolean;
+			abortOnError?: boolean;
 		} = {},
 	) {
 		const io = {
@@ -156,8 +156,8 @@ export class Interpreter {
 	@autobind
 	private handleError(e: unknown): void {
 		if (!this.opts.err) throw e;
-		if (this.opts.failToAbort) {
-			// when failToAbort is true, error handler should be called only once
+		if (this.opts.abortOnError) {
+			// when abortOnError is true, error handler should be called only once
 			if (this.stop) return;
 			this.abort();
 		}

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -157,9 +157,9 @@ export class Interpreter {
 	private handleError(e: unknown): void {
 		if (!this.opts.err) throw e;
 		if (this.opts.failToAbort) {
-			// when failToAbort is true error handler should be called only once
+			// when failToAbort is true, error handler should be called only once
 			if (this.stop) return;
-			else this.abort();
+			this.abort();
 		}
 		if (e instanceof AiScriptError) {
 			this.opts.err(e);

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -31,6 +31,7 @@ export class Interpreter {
 			err?(e: AiScriptError): void;
 			log?(type: string, params: Record<string, any>): void;
 			maxStep?: number;
+			failToAbort?: boolean;
 		} = {},
 	) {
 		const io = {
@@ -153,19 +154,17 @@ export class Interpreter {
 	}
 
 	@autobind
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	private handleError(e: any): void {
-		if (this.opts.err) {
-			if (!this.stop) {
-				this.abort();
-				if (e instanceof AiScriptError) {
-					this.opts.err(e);
-				} else {
-					this.opts.err(new NonAiScriptError(e));
-				}
-			}
+	private handleError(e: unknown): void {
+		if (!this.opts.err) throw e;
+		if (this.opts.failToAbort) {
+			// when failToAbort is true error handler should be called only once
+			if (this.stop) return;
+			else this.abort();
+		}
+		if (e instanceof AiScriptError) {
+			this.opts.err(e);
 		} else {
-			throw e;
+			this.opts.err(new NonAiScriptError(e));
 		}
 	}
 

--- a/unreleased/optinabort.md
+++ b/unreleased/optinabort.md
@@ -1,0 +1,1 @@
+- For Hosts: エラーハンドラ使用時、InterpreterのオプションでfailToAbortをtrueにした時のみ全体のabortを行うように

--- a/unreleased/optinabort.md
+++ b/unreleased/optinabort.md
@@ -1,1 +1,1 @@
-- For Hosts: エラーハンドラ使用時、InterpreterのオプションでfailToAbortをtrueにした時のみ全体のabortを行うように
+- For Hosts: エラーハンドラ使用時、InterpreterのオプションでabortOnErrorをtrueにした時のみ全体のabortを行うように


### PR DESCRIPTION
## what
これまでInterpreterにエラーハンドラが設定されていた場合、一度エラーが出るとAiScriptの処理全体を停止するようになっていましたが、この挙動をオプトイン化し、デフォルトでは一つのプロセスが停止しても他のプロセスは継続して稼働するようにします。

## why
Fix #710
Close https://github.com/misskey-dev/misskey/pull/14117