### PR TITLE
Locにノードの終了位置を追加

### DIFF
--- a/etc/aiscript.api.md
+++ b/etc/aiscript.api.md
@@ -22,9 +22,9 @@ abstract class AiScriptError extends Error {
     // (undocumented)
     info?: any;
     // (undocumented)
-    loc?: Loc;
-    // (undocumented)
     name: string;
+    // (undocumented)
+    pos?: Pos;
 }
 
 // @public
@@ -34,11 +34,11 @@ class AiScriptIndexOutOfRangeError extends AiScriptRuntimeError {
 
 // @public
 class AiScriptNamespaceError extends AiScriptError {
-    constructor(message: string, loc: Loc, info?: any);
-    // (undocumented)
-    loc: Loc;
+    constructor(message: string, pos: Pos, info?: any);
     // (undocumented)
     name: string;
+    // (undocumented)
+    pos: Pos;
 }
 
 // @public
@@ -50,20 +50,20 @@ class AiScriptRuntimeError extends AiScriptError {
 
 // @public
 class AiScriptSyntaxError extends AiScriptError {
-    constructor(message: string, loc: Loc, info?: any);
-    // (undocumented)
-    loc: Loc;
+    constructor(message: string, pos: Pos, info?: any);
     // (undocumented)
     name: string;
+    // (undocumented)
+    pos: Pos;
 }
 
 // @public
 class AiScriptTypeError extends AiScriptError {
-    constructor(message: string, loc: Loc, info?: any);
-    // (undocumented)
-    loc: Loc;
+    constructor(message: string, pos: Pos, info?: any);
     // (undocumented)
     name: string;
+    // (undocumented)
+    pos: Pos;
 }
 
 // @public
@@ -119,6 +119,7 @@ declare namespace Ast {
     export {
         isStatement,
         isExpression,
+        Pos,
         Loc,
         Node_2 as Node,
         Namespace,
@@ -390,10 +391,10 @@ function isString(val: Value): val is VStr;
 // @public (undocumented)
 function jsToVal(val: any): Value;
 
-// @public
+// @public (undocumented)
 type Loc = {
-    line: number;
-    column: number;
+    start: Pos;
+    end: Pos;
 };
 
 // @public (undocumented)
@@ -502,6 +503,12 @@ export type ParserPlugin = (nodes: Ast.Node[]) => Ast.Node[];
 
 // @public (undocumented)
 export type PluginType = 'validate' | 'transform';
+
+// @public
+type Pos = {
+    line: number;
+    column: number;
+};
 
 // @public (undocumented)
 type Prop = NodeBase & {

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { Loc } from './node.js';
+import type { Pos } from './node.js';
 
 export abstract class AiScriptError extends Error {
 	// name is read by Error.prototype.toString
 	public name = 'AiScript';
 	public info?: any;
-	public loc?: Loc;
+	public pos?: Pos;
 
 	constructor(message: string, info?: any) {
 		super(message);
@@ -34,8 +34,8 @@ export class NonAiScriptError extends AiScriptError {
  */
 export class AiScriptSyntaxError extends AiScriptError {
 	public name = 'Syntax';
-	constructor(message: string, public loc: Loc, info?: any) {
-		super(`${message} (Line ${loc.line}, Column ${loc.column})`, info);
+	constructor(message: string, public pos: Pos, info?: any) {
+		super(`${message} (Line ${pos.line}, Column ${pos.column})`, info);
 	}
 }
 /**
@@ -43,8 +43,8 @@ export class AiScriptSyntaxError extends AiScriptError {
  */ 
 export class AiScriptTypeError extends AiScriptError {
 	public name = 'Type';
-	constructor(message: string, public loc: Loc, info?: any) {
-		super(`${message} (Line ${loc.line}, Column ${loc.column})`, info);
+	constructor(message: string, public pos: Pos, info?: any) {
+		super(`${message} (Line ${pos.line}, Column ${pos.column})`, info);
 	}
 }
 
@@ -53,8 +53,8 @@ export class AiScriptTypeError extends AiScriptError {
  */
 export class AiScriptNamespaceError extends AiScriptError {
 	public name = 'Namespace';
-	constructor(message: string, public loc: Loc, info?: any) {
-		super(`${message} (Line ${loc.line}, Column ${loc.column})`, info);
+	constructor(message: string, public pos: Pos, info?: any) {
+		super(`${message} (Line ${pos.line}, Column ${pos.column})`, info);
 	}
 }
 

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -191,7 +191,7 @@ export class Interpreter {
 			switch (node.type) {
 				case 'def': {
 					if (node.mut) {
-						throw new AiScriptNamespaceError('No "var" in namespace declaration: ' + node.name, node.loc);
+						throw new AiScriptNamespaceError('No "var" in namespace declaration: ' + node.name, node.loc.start);
 					}
 
 					const variable: Variable = {
@@ -211,7 +211,7 @@ export class Interpreter {
 					// exhaustiveness check
 					const n: never = node;
 					const nd = n as Ast.Node;
-					throw new AiScriptNamespaceError('invalid ns member type: ' + nd.type, nd.loc);
+					throw new AiScriptNamespaceError('invalid ns member type: ' + nd.type, nd.loc.start);
 				}
 			}
 		}
@@ -246,11 +246,11 @@ export class Interpreter {
 	@autobind
 	private _eval(node: Ast.Node, scope: Scope): Promise<Value> {
 		return this.__eval(node, scope).catch(e => {
-			if (e.loc) throw e;
+			if (e.pos) throw e;
 			else {
 				const e2 = (e instanceof AiScriptError) ? e : new NonAiScriptError(e);
-				e2.loc = node.loc;
-				e2.message = `${e2.message} (Line ${node.loc.line}, Column ${node.loc.column})`;
+				e2.pos = node.loc.start;
+				e2.message = `${e2.message} (Line ${e2.pos.line}, Column ${e2.pos.column})`;
 				throw e2;
 			}
 		});

--- a/src/node.ts
+++ b/src/node.ts
@@ -2,9 +2,14 @@
  * ASTノード
 */
 
-export type Loc = {
+export type Pos = {
 	line: number;
 	column: number;
+};
+
+export type Loc = {
+	start: Pos;
+	end: Pos;
 };
 
 export type Node = Namespace | Meta | Statement | Expression | TypeSource | Attribute;

--- a/src/parser/plugins/validate-keyword.ts
+++ b/src/parser/plugins/validate-keyword.ts
@@ -53,7 +53,7 @@ const reservedWord = [
 ];
 
 function throwReservedWordError(name: string, loc: Ast.Loc): void {
-	throw new AiScriptSyntaxError(`Reserved word "${name}" cannot be used as variable name.`, loc);
+	throw new AiScriptSyntaxError(`Reserved word "${name}" cannot be used as variable name.`, loc.start);
 }
 
 function validateNode(node: Ast.Node): Ast.Node {

--- a/src/parser/scanner.ts
+++ b/src/parser/scanner.ts
@@ -576,12 +576,14 @@ export class Scanner implements ITokenStream {
 					}
 					// 埋め込み式の終了
 					if ((this.stream.char as string) === '}') {
-						this.stream.next();
 						elements.push(TOKEN(TokenKind.TemplateExprElement, elementLoc, { hasLeftSpacing, children: tokenBuf }));
-						tokenBuf = [];
 						// ここから文字列エレメントになるので位置を更新
 						elementLoc = this.stream.getPos();
+						// TemplateExprElementトークンの終了位置をTokenStreamが取得するためのEOFトークンを追加
+						tokenBuf.push(TOKEN(TokenKind.EOF, elementLoc));
+						tokenBuf = [];
 						state = 'string';
+						this.stream.next();
 						break;
 					}
 					const token = this.readToken();

--- a/src/parser/scanner.ts
+++ b/src/parser/scanner.ts
@@ -46,7 +46,7 @@ export class Scanner implements ITokenStream {
 	 * カーソル位置にあるトークンの位置情報を取得します。
 	*/
 	public getPos(): TokenLocation {
-		return this.token.loc;
+		return this.token.pos;
 	}
 
 	/**

--- a/src/parser/scanner.ts
+++ b/src/parser/scanner.ts
@@ -3,7 +3,7 @@ import { CharStream } from './streams/char-stream.js';
 import { TOKEN, TokenKind } from './token.js';
 
 import type { ITokenStream } from './streams/token-stream.js';
-import type { Token, TokenLocation } from './token.js';
+import type { Token, TokenPosition } from './token.js';
 
 const spaceChars = [' ', '\t'];
 const lineBreakChars = ['\r', '\n'];
@@ -45,7 +45,7 @@ export class Scanner implements ITokenStream {
 	/**
 	 * カーソル位置にあるトークンの位置情報を取得します。
 	*/
-	public getPos(): TokenLocation {
+	public getPos(): TokenPosition {
 		return this.token.pos;
 	}
 
@@ -112,11 +112,11 @@ export class Scanner implements ITokenStream {
 			}
 
 			// トークン位置を記憶
-			const loc = this.stream.getPos();
+			const pos = this.stream.getPos();
 
 			if (lineBreakChars.includes(this.stream.char)) {
 				this.stream.next();
-				token = TOKEN(TokenKind.NewLine, loc, { hasLeftSpacing });
+				token = TOKEN(TokenKind.NewLine, pos, { hasLeftSpacing });
 				return token;
 			}
 			switch (this.stream.char) {
@@ -124,9 +124,9 @@ export class Scanner implements ITokenStream {
 					this.stream.next();
 					if (!this.stream.eof && (this.stream.char as string) === '=') {
 						this.stream.next();
-						token = TOKEN(TokenKind.NotEq, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.NotEq, pos, { hasLeftSpacing });
 					} else {
-						token = TOKEN(TokenKind.Not, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Not, pos, { hasLeftSpacing });
 					}
 					break;
 				}
@@ -141,72 +141,72 @@ export class Scanner implements ITokenStream {
 						this.stream.next();
 						if (!this.stream.eof && (this.stream.char as string) === '#') {
 							this.stream.next();
-							token = TOKEN(TokenKind.Sharp3, loc, { hasLeftSpacing });
+							token = TOKEN(TokenKind.Sharp3, pos, { hasLeftSpacing });
 						}
 					} else if (!this.stream.eof && (this.stream.char as string) === '[') {
 						this.stream.next();
-						token = TOKEN(TokenKind.OpenSharpBracket, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.OpenSharpBracket, pos, { hasLeftSpacing });
 					} else {
-						throw new AiScriptSyntaxError('invalid character: "#"', loc);
+						throw new AiScriptSyntaxError('invalid character: "#"', pos);
 					}
 					break;
 				}
 				case '%': {
 					this.stream.next();
-					token = TOKEN(TokenKind.Percent, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.Percent, pos, { hasLeftSpacing });
 					break;
 				}
 				case '&': {
 					this.stream.next();
 					if (!this.stream.eof && (this.stream.char as string) === '&') {
 						this.stream.next();
-						token = TOKEN(TokenKind.And2, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.And2, pos, { hasLeftSpacing });
 					}
 					break;
 				}
 				case '(': {
 					this.stream.next();
-					token = TOKEN(TokenKind.OpenParen, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.OpenParen, pos, { hasLeftSpacing });
 					break;
 				}
 				case ')': {
 					this.stream.next();
-					token = TOKEN(TokenKind.CloseParen, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.CloseParen, pos, { hasLeftSpacing });
 					break;
 				}
 				case '*': {
 					this.stream.next();
-					token = TOKEN(TokenKind.Asterisk, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.Asterisk, pos, { hasLeftSpacing });
 					break;
 				}
 				case '+': {
 					this.stream.next();
 					if (!this.stream.eof && (this.stream.char as string) === '=') {
 						this.stream.next();
-						token = TOKEN(TokenKind.PlusEq, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.PlusEq, pos, { hasLeftSpacing });
 					} else {
-						token = TOKEN(TokenKind.Plus, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Plus, pos, { hasLeftSpacing });
 					}
 					break;
 				}
 				case ',': {
 					this.stream.next();
-					token = TOKEN(TokenKind.Comma, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.Comma, pos, { hasLeftSpacing });
 					break;
 				}
 				case '-': {
 					this.stream.next();
 					if (!this.stream.eof && (this.stream.char as string) === '=') {
 						this.stream.next();
-						token = TOKEN(TokenKind.MinusEq, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.MinusEq, pos, { hasLeftSpacing });
 					} else {
-						token = TOKEN(TokenKind.Minus, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Minus, pos, { hasLeftSpacing });
 					}
 					break;
 				}
 				case '.': {
 					this.stream.next();
-					token = TOKEN(TokenKind.Dot, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.Dot, pos, { hasLeftSpacing });
 					break;
 				}
 				case '/': {
@@ -220,7 +220,7 @@ export class Scanner implements ITokenStream {
 						this.skipCommentLine();
 						continue;
 					} else {
-						token = TOKEN(TokenKind.Slash, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Slash, pos, { hasLeftSpacing });
 					}
 					break;
 				}
@@ -228,27 +228,27 @@ export class Scanner implements ITokenStream {
 					this.stream.next();
 					if (!this.stream.eof && (this.stream.char as string) === ':') {
 						this.stream.next();
-						token = TOKEN(TokenKind.Colon2, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Colon2, pos, { hasLeftSpacing });
 					} else {
-						token = TOKEN(TokenKind.Colon, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Colon, pos, { hasLeftSpacing });
 					}
 					break;
 				}
 				case ';': {
 					this.stream.next();
-					token = TOKEN(TokenKind.SemiColon, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.SemiColon, pos, { hasLeftSpacing });
 					break;
 				}
 				case '<': {
 					this.stream.next();
 					if (!this.stream.eof && (this.stream.char as string) === '=') {
 						this.stream.next();
-						token = TOKEN(TokenKind.LtEq, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.LtEq, pos, { hasLeftSpacing });
 					} else if (!this.stream.eof && (this.stream.char as string) === ':') {
 						this.stream.next();
-						token = TOKEN(TokenKind.Out, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Out, pos, { hasLeftSpacing });
 					} else {
-						token = TOKEN(TokenKind.Lt, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Lt, pos, { hasLeftSpacing });
 					}
 					break;
 				}
@@ -256,12 +256,12 @@ export class Scanner implements ITokenStream {
 					this.stream.next();
 					if (!this.stream.eof && (this.stream.char as string) === '=') {
 						this.stream.next();
-						token = TOKEN(TokenKind.Eq2, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Eq2, pos, { hasLeftSpacing });
 					} else if (!this.stream.eof && (this.stream.char as string) === '>') {
 						this.stream.next();
-						token = TOKEN(TokenKind.Arrow, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Arrow, pos, { hasLeftSpacing });
 					} else {
-						token = TOKEN(TokenKind.Eq, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Eq, pos, { hasLeftSpacing });
 					}
 					break;
 				}
@@ -269,40 +269,40 @@ export class Scanner implements ITokenStream {
 					this.stream.next();
 					if (!this.stream.eof && (this.stream.char as string) === '=') {
 						this.stream.next();
-						token = TOKEN(TokenKind.GtEq, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.GtEq, pos, { hasLeftSpacing });
 					} else {
-						token = TOKEN(TokenKind.Gt, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Gt, pos, { hasLeftSpacing });
 					}
 					break;
 				}
 				case '?': {
 					this.stream.next();
-					token = TOKEN(TokenKind.Question, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.Question, pos, { hasLeftSpacing });
 					break;
 				}
 				case '@': {
 					this.stream.next();
-					token = TOKEN(TokenKind.At, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.At, pos, { hasLeftSpacing });
 					break;
 				}
 				case '[': {
 					this.stream.next();
-					token = TOKEN(TokenKind.OpenBracket, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.OpenBracket, pos, { hasLeftSpacing });
 					break;
 				}
 				case '\\': {
 					this.stream.next();
-					token = TOKEN(TokenKind.BackSlash, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.BackSlash, pos, { hasLeftSpacing });
 					break;
 				}
 				case ']': {
 					this.stream.next();
-					token = TOKEN(TokenKind.CloseBracket, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.CloseBracket, pos, { hasLeftSpacing });
 					break;
 				}
 				case '^': {
 					this.stream.next();
-					token = TOKEN(TokenKind.Hat, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.Hat, pos, { hasLeftSpacing });
 					break;
 				}
 				case '`': {
@@ -311,20 +311,20 @@ export class Scanner implements ITokenStream {
 				}
 				case '{': {
 					this.stream.next();
-					token = TOKEN(TokenKind.OpenBrace, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.OpenBrace, pos, { hasLeftSpacing });
 					break;
 				}
 				case '|': {
 					this.stream.next();
 					if (!this.stream.eof && (this.stream.char as string) === '|') {
 						this.stream.next();
-						token = TOKEN(TokenKind.Or2, loc, { hasLeftSpacing });
+						token = TOKEN(TokenKind.Or2, pos, { hasLeftSpacing });
 					}
 					break;
 				}
 				case '}': {
 					this.stream.next();
-					token = TOKEN(TokenKind.CloseBrace, loc, { hasLeftSpacing });
+					token = TOKEN(TokenKind.CloseBrace, pos, { hasLeftSpacing });
 					break;
 				}
 			}
@@ -339,7 +339,7 @@ export class Scanner implements ITokenStream {
 					token = wordToken;
 					break;
 				}
-				throw new AiScriptSyntaxError(`invalid character: "${this.stream.char}"`, loc);
+				throw new AiScriptSyntaxError(`invalid character: "${this.stream.char}"`, pos);
 			}
 			break;
 		}
@@ -350,7 +350,7 @@ export class Scanner implements ITokenStream {
 		// read a word
 		let value = '';
 
-		const loc = this.stream.getPos();
+		const pos = this.stream.getPos();
 
 		while (!this.stream.eof && wordChar.test(this.stream.char)) {
 			value += this.stream.char;
@@ -362,70 +362,70 @@ export class Scanner implements ITokenStream {
 		// check word kind
 		switch (value) {
 			case 'null': {
-				return TOKEN(TokenKind.NullKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.NullKeyword, pos, { hasLeftSpacing });
 			}
 			case 'true': {
-				return TOKEN(TokenKind.TrueKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.TrueKeyword, pos, { hasLeftSpacing });
 			}
 			case 'false': {
-				return TOKEN(TokenKind.FalseKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.FalseKeyword, pos, { hasLeftSpacing });
 			}
 			case 'each': {
-				return TOKEN(TokenKind.EachKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.EachKeyword, pos, { hasLeftSpacing });
 			}
 			case 'for': {
-				return TOKEN(TokenKind.ForKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.ForKeyword, pos, { hasLeftSpacing });
 			}
 			case 'loop': {
-				return TOKEN(TokenKind.LoopKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.LoopKeyword, pos, { hasLeftSpacing });
 			}
 			case 'do': {
-				return TOKEN(TokenKind.DoKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.DoKeyword, pos, { hasLeftSpacing });
 			}
 			case 'while': {
-				return TOKEN(TokenKind.WhileKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.WhileKeyword, pos, { hasLeftSpacing });
 			}
 			case 'break': {
-				return TOKEN(TokenKind.BreakKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.BreakKeyword, pos, { hasLeftSpacing });
 			}
 			case 'continue': {
-				return TOKEN(TokenKind.ContinueKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.ContinueKeyword, pos, { hasLeftSpacing });
 			}
 			case 'match': {
-				return TOKEN(TokenKind.MatchKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.MatchKeyword, pos, { hasLeftSpacing });
 			}
 			case 'case': {
-				return TOKEN(TokenKind.CaseKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.CaseKeyword, pos, { hasLeftSpacing });
 			}
 			case 'default': {
-				return TOKEN(TokenKind.DefaultKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.DefaultKeyword, pos, { hasLeftSpacing });
 			}
 			case 'if': {
-				return TOKEN(TokenKind.IfKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.IfKeyword, pos, { hasLeftSpacing });
 			}
 			case 'elif': {
-				return TOKEN(TokenKind.ElifKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.ElifKeyword, pos, { hasLeftSpacing });
 			}
 			case 'else': {
-				return TOKEN(TokenKind.ElseKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.ElseKeyword, pos, { hasLeftSpacing });
 			}
 			case 'return': {
-				return TOKEN(TokenKind.ReturnKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.ReturnKeyword, pos, { hasLeftSpacing });
 			}
 			case 'eval': {
-				return TOKEN(TokenKind.EvalKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.EvalKeyword, pos, { hasLeftSpacing });
 			}
 			case 'var': {
-				return TOKEN(TokenKind.VarKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.VarKeyword, pos, { hasLeftSpacing });
 			}
 			case 'let': {
-				return TOKEN(TokenKind.LetKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.LetKeyword, pos, { hasLeftSpacing });
 			}
 			case 'exists': {
-				return TOKEN(TokenKind.ExistsKeyword, loc, { hasLeftSpacing });
+				return TOKEN(TokenKind.ExistsKeyword, pos, { hasLeftSpacing });
 			}
 			default: {
-				return TOKEN(TokenKind.Identifier, loc, { hasLeftSpacing, value });
+				return TOKEN(TokenKind.Identifier, pos, { hasLeftSpacing, value });
 			}
 		}
 	}
@@ -434,7 +434,7 @@ export class Scanner implements ITokenStream {
 		let wholeNumber = '';
 		let fractional = '';
 
-		const loc = this.stream.getPos();
+		const pos = this.stream.getPos();
 
 		while (!this.stream.eof && digit.test(this.stream.char)) {
 			wholeNumber += this.stream.char;
@@ -450,7 +450,7 @@ export class Scanner implements ITokenStream {
 				this.stream.next();
 			}
 			if (fractional.length === 0) {
-				throw new AiScriptSyntaxError('digit expected', loc);
+				throw new AiScriptSyntaxError('digit expected', pos);
 			}
 		}
 		let value;
@@ -459,7 +459,7 @@ export class Scanner implements ITokenStream {
 		} else {
 			value = wholeNumber;
 		}
-		return TOKEN(TokenKind.NumberLiteral, loc, { hasLeftSpacing, value });
+		return TOKEN(TokenKind.NumberLiteral, pos, { hasLeftSpacing, value });
 	}
 
 	private readStringLiteral(hasLeftSpacing: boolean): Token {
@@ -467,14 +467,14 @@ export class Scanner implements ITokenStream {
 		const literalMark = this.stream.char;
 		let state: 'string' | 'escape' | 'finish' = 'string';
 
-		const loc = this.stream.getPos();
+		const pos = this.stream.getPos();
 		this.stream.next();
 
 		while (state !== 'finish') {
 			switch (state) {
 				case 'string': {
 					if (this.stream.eof) {
-						throw new AiScriptSyntaxError('unexpected EOF', loc);
+						throw new AiScriptSyntaxError('unexpected EOF', pos);
 					}
 					if (this.stream.char === '\\') {
 						this.stream.next();
@@ -492,7 +492,7 @@ export class Scanner implements ITokenStream {
 				}
 				case 'escape': {
 					if (this.stream.eof) {
-						throw new AiScriptSyntaxError('unexpected EOF', loc);
+						throw new AiScriptSyntaxError('unexpected EOF', pos);
 					}
 					value += this.stream.char;
 					this.stream.next();
@@ -501,7 +501,7 @@ export class Scanner implements ITokenStream {
 				}
 			}
 		}
-		return TOKEN(TokenKind.StringLiteral, loc, { hasLeftSpacing, value });
+		return TOKEN(TokenKind.StringLiteral, pos, { hasLeftSpacing, value });
 	}
 
 	private readTemplate(hasLeftSpacing: boolean): Token {
@@ -510,8 +510,8 @@ export class Scanner implements ITokenStream {
 		let tokenBuf: Token[] = [];
 		let state: 'string' | 'escape' | 'expr' | 'finish' = 'string';
 
-		const loc = this.stream.getPos();
-		let elementLoc = loc;
+		const pos = this.stream.getPos();
+		let elementPos = pos;
 		this.stream.next();
 
 		while (state !== 'finish') {
@@ -519,7 +519,7 @@ export class Scanner implements ITokenStream {
 				case 'string': {
 					// テンプレートの終了が無いままEOFに達した
 					if (this.stream.eof) {
-						throw new AiScriptSyntaxError('unexpected EOF', loc);
+						throw new AiScriptSyntaxError('unexpected EOF', pos);
 					}
 					// エスケープ
 					if (this.stream.char === '\\') {
@@ -531,7 +531,7 @@ export class Scanner implements ITokenStream {
 					if (this.stream.char === '`') {
 						this.stream.next();
 						if (buf.length > 0) {
-							elements.push(TOKEN(TokenKind.TemplateStringElement, elementLoc, { hasLeftSpacing, value: buf }));
+							elements.push(TOKEN(TokenKind.TemplateStringElement, elementPos, { hasLeftSpacing, value: buf }));
 						}
 						state = 'finish';
 						break;
@@ -540,11 +540,11 @@ export class Scanner implements ITokenStream {
 					if (this.stream.char === '{') {
 						this.stream.next();
 						if (buf.length > 0) {
-							elements.push(TOKEN(TokenKind.TemplateStringElement, elementLoc, { hasLeftSpacing, value: buf }));
+							elements.push(TOKEN(TokenKind.TemplateStringElement, elementPos, { hasLeftSpacing, value: buf }));
 							buf = '';
 						}
 						// ここから式エレメントになるので位置を更新
-						elementLoc = this.stream.getPos();
+						elementPos = this.stream.getPos();
 						state = 'expr';
 						break;
 					}
@@ -555,7 +555,7 @@ export class Scanner implements ITokenStream {
 				case 'escape': {
 					// エスケープ対象の文字が無いままEOFに達した
 					if (this.stream.eof) {
-						throw new AiScriptSyntaxError('unexpected EOF', loc);
+						throw new AiScriptSyntaxError('unexpected EOF', pos);
 					}
 					// 普通の文字として取り込み
 					buf += this.stream.char;
@@ -567,7 +567,7 @@ export class Scanner implements ITokenStream {
 				case 'expr': {
 					// 埋め込み式の終端記号が無いままEOFに達した
 					if (this.stream.eof) {
-						throw new AiScriptSyntaxError('unexpected EOF', loc);
+						throw new AiScriptSyntaxError('unexpected EOF', pos);
 					}
 					// skip spasing
 					if (spaceChars.includes(this.stream.char)) {
@@ -576,11 +576,11 @@ export class Scanner implements ITokenStream {
 					}
 					// 埋め込み式の終了
 					if ((this.stream.char as string) === '}') {
-						elements.push(TOKEN(TokenKind.TemplateExprElement, elementLoc, { hasLeftSpacing, children: tokenBuf }));
+						elements.push(TOKEN(TokenKind.TemplateExprElement, elementPos, { hasLeftSpacing, children: tokenBuf }));
 						// ここから文字列エレメントになるので位置を更新
-						elementLoc = this.stream.getPos();
+						elementPos = this.stream.getPos();
 						// TemplateExprElementトークンの終了位置をTokenStreamが取得するためのEOFトークンを追加
-						tokenBuf.push(TOKEN(TokenKind.EOF, elementLoc));
+						tokenBuf.push(TOKEN(TokenKind.EOF, elementPos));
 						tokenBuf = [];
 						state = 'string';
 						this.stream.next();
@@ -593,7 +593,7 @@ export class Scanner implements ITokenStream {
 			}
 		}
 
-		return TOKEN(TokenKind.Template, loc, { hasLeftSpacing, children: elements });
+		return TOKEN(TokenKind.Template, pos, { hasLeftSpacing, children: elements });
 	}
 
 	private skipCommentLine(): void {

--- a/src/parser/scanner.ts
+++ b/src/parser/scanner.ts
@@ -3,7 +3,7 @@ import { CharStream } from './streams/char-stream.js';
 import { TOKEN, TokenKind } from './token.js';
 
 import type { ITokenStream } from './streams/token-stream.js';
-import type { Token } from './token.js';
+import type { Token, TokenLocation } from './token.js';
 
 const spaceChars = [' ', '\t'];
 const lineBreakChars = ['\r', '\n'];
@@ -43,6 +43,13 @@ export class Scanner implements ITokenStream {
 	}
 
 	/**
+	 * カーソル位置にあるトークンの位置情報を取得します。
+	*/
+	public getPos(): TokenLocation {
+		return this.token.loc;
+	}
+
+	/**
 	 * カーソル位置を次のトークンへ進めます。
 	*/
 	public next(): void {
@@ -75,7 +82,7 @@ export class Scanner implements ITokenStream {
 	*/
 	public expect(kind: TokenKind): void {
 		if (this.getKind() !== kind) {
-			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[this.getKind()]}`, this.token.loc);
+			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[this.getKind()]}`, this.getPos());
 		}
 	}
 

--- a/src/parser/streams/token-stream.ts
+++ b/src/parser/streams/token-stream.ts
@@ -83,7 +83,7 @@ export class TokenStream implements ITokenStream {
 	 * カーソル位置にあるトークンの位置情報を取得します。
 	*/
 	public getPos(): TokenLocation {
-		return this.token.loc;
+		return this.token.pos;
 	}
 
 	/**

--- a/src/parser/streams/token-stream.ts
+++ b/src/parser/streams/token-stream.ts
@@ -1,6 +1,6 @@
 import { AiScriptSyntaxError } from '../../error.js';
 import { TOKEN, TokenKind } from '../token.js';
-import type { Token } from '../token.js';
+import type { Token, TokenLocation } from '../token.js';
 
 /**
  * トークンの読み取りに関するインターフェース
@@ -15,6 +15,11 @@ export interface ITokenStream {
 	 * カーソル位置にあるトークンの種類を取得します。
 	*/
 	getKind(): TokenKind;
+
+	/**
+	 * カーソル位置にあるトークンの位置情報を取得します。
+	*/
+	getPos(): TokenLocation;
 
 	/**
 	 * カーソル位置を次のトークンへ進めます。
@@ -75,6 +80,13 @@ export class TokenStream implements ITokenStream {
 	}
 
 	/**
+	 * カーソル位置にあるトークンの位置情報を取得します。
+	*/
+	public getPos(): TokenLocation {
+		return this.token.loc;
+	}
+
+	/**
 	 * カーソル位置を次のトークンへ進めます。
 	*/
 	public next(): void {
@@ -101,7 +113,7 @@ export class TokenStream implements ITokenStream {
 	*/
 	public expect(kind: TokenKind): void {
 		if (this.getKind() !== kind) {
-			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[this.getKind()]}`, this.token.loc);
+			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[this.getKind()]}`, this.getPos());
 		}
 	}
 

--- a/src/parser/streams/token-stream.ts
+++ b/src/parser/streams/token-stream.ts
@@ -1,6 +1,6 @@
 import { AiScriptSyntaxError } from '../../error.js';
 import { TOKEN, TokenKind } from '../token.js';
-import type { Token, TokenLocation } from '../token.js';
+import type { Token, TokenPosition } from '../token.js';
 
 /**
  * トークンの読み取りに関するインターフェース
@@ -19,7 +19,7 @@ export interface ITokenStream {
 	/**
 	 * カーソル位置にあるトークンの位置情報を取得します。
 	*/
-	getPos(): TokenLocation;
+	getPos(): TokenPosition;
 
 	/**
 	 * カーソル位置を次のトークンへ進めます。
@@ -82,7 +82,7 @@ export class TokenStream implements ITokenStream {
 	/**
 	 * カーソル位置にあるトークンの位置情報を取得します。
 	*/
-	public getPos(): TokenLocation {
+	public getPos(): TokenPosition {
 		return this.token.pos;
 	}
 

--- a/src/parser/syntaxes/common.ts
+++ b/src/parser/syntaxes/common.ts
@@ -126,7 +126,7 @@ export function parseType(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseFnType(s: ITokenStream): Ast.Node {
-	const loc = s.token.loc;
+	const startPos = s.token.loc;
 
 	s.nextWith(TokenKind.At);
 	s.nextWith(TokenKind.OpenParen);
@@ -153,7 +153,7 @@ function parseFnType(s: ITokenStream): Ast.Node {
 
 	const resultType = parseType(s);
 
-	return NODE('fnTypeSource', { args: params, result: resultType }, loc);
+	return NODE('fnTypeSource', { args: params, result: resultType }, startPos, s.token.loc);
 }
 
 /**
@@ -162,7 +162,7 @@ function parseFnType(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseNamedType(s: ITokenStream): Ast.Node {
-	const loc = s.token.loc;
+	const startPos = s.token.loc;
 
 	s.expect(TokenKind.Identifier);
 	const name = s.token.value!;
@@ -176,7 +176,7 @@ function parseNamedType(s: ITokenStream): Ast.Node {
 		s.nextWith(TokenKind.Gt);
 	}
 
-	return NODE('namedTypeSource', { name, inner }, loc);
+	return NODE('namedTypeSource', { name, inner }, startPos, s.token.loc);
 }
 
 //#endregion Type

--- a/src/parser/syntaxes/common.ts
+++ b/src/parser/syntaxes/common.ts
@@ -60,7 +60,7 @@ export function parseParams(s: ITokenStream): { name: string, argType?: Ast.Node
 				break;
 			}
 			default: {
-				throw new AiScriptSyntaxError('separator expected', s.token.loc);
+				throw new AiScriptSyntaxError('separator expected', s.getPos());
 			}
 		}
 	}
@@ -99,7 +99,7 @@ export function parseBlock(s: ITokenStream): Ast.Node[] {
 				break;
 			}
 			default: {
-				throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.', s.token.loc);
+				throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.', s.getPos());
 			}
 		}
 	}
@@ -126,7 +126,7 @@ export function parseType(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseFnType(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 
 	s.nextWith(TokenKind.At);
 	s.nextWith(TokenKind.OpenParen);
@@ -140,7 +140,7 @@ function parseFnType(s: ITokenStream): Ast.Node {
 					break;
 				}
 				default: {
-					throw new AiScriptSyntaxError('separator expected', s.token.loc);
+					throw new AiScriptSyntaxError('separator expected', s.getPos());
 				}
 			}
 		}
@@ -153,7 +153,7 @@ function parseFnType(s: ITokenStream): Ast.Node {
 
 	const resultType = parseType(s);
 
-	return NODE('fnTypeSource', { args: params, result: resultType }, startPos, s.token.loc);
+	return NODE('fnTypeSource', { args: params, result: resultType }, startPos, s.getPos());
 }
 
 /**
@@ -162,7 +162,7 @@ function parseFnType(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseNamedType(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 
 	s.expect(TokenKind.Identifier);
 	const name = s.token.value!;
@@ -176,7 +176,7 @@ function parseNamedType(s: ITokenStream): Ast.Node {
 		s.nextWith(TokenKind.Gt);
 	}
 
-	return NODE('namedTypeSource', { name, inner }, startPos, s.token.loc);
+	return NODE('namedTypeSource', { name, inner }, startPos, s.getPos());
 }
 
 //#endregion Type

--- a/src/parser/syntaxes/expressions.ts
+++ b/src/parser/syntaxes/expressions.ts
@@ -228,7 +228,7 @@ function parseAtom(s: ITokenStream, isStatic: boolean): Ast.Node {
 					case TokenKind.TemplateStringElement: {
 						// トークンの終了位置を取得するために先読み
 						const nextToken = s.token.children![i + 1] ?? s.lookahead(1);
-						values.push(NODE('str', { value: element.value! }, element.loc, nextToken.loc));
+						values.push(NODE('str', { value: element.value! }, element.pos, nextToken.pos));
 						break;
 					}
 					case TokenKind.TemplateExprElement: {
@@ -236,13 +236,13 @@ function parseAtom(s: ITokenStream, isStatic: boolean): Ast.Node {
 						const exprStream = new TokenStream(element.children!);
 						const expr = parseExpr(exprStream, false);
 						if (exprStream.getKind() !== TokenKind.EOF) {
-							throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[exprStream.token.kind]}`, exprStream.token.loc);
+							throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[exprStream.token.kind]}`, exprStream.token.pos);
 						}
 						values.push(expr);
 						break;
 					}
 					default: {
-						throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[element.kind]}`, element.loc);
+						throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[element.kind]}`, element.pos);
 					}
 				}
 			}

--- a/src/parser/syntaxes/statements.ts
+++ b/src/parser/syntaxes/statements.ts
@@ -443,24 +443,24 @@ function parseWhile(s: ITokenStream): Ast.Node {
  * ```
 */
 function tryParseAssign(s: ITokenStream, dest: Ast.Node): Ast.Node | undefined {
-	const loc = s.getPos();
+	const startPos = s.getPos();
 
 	// Assign
 	switch (s.getKind()) {
 		case TokenKind.Eq: {
 			s.next();
 			const expr = parseExpr(s, false);
-			return NODE('assign', { dest, expr }, loc, s.getPos());
+			return NODE('assign', { dest, expr }, startPos, s.getPos());
 		}
 		case TokenKind.PlusEq: {
 			s.next();
 			const expr = parseExpr(s, false);
-			return NODE('addAssign', { dest, expr }, loc, s.getPos());
+			return NODE('addAssign', { dest, expr }, startPos, s.getPos());
 		}
 		case TokenKind.MinusEq: {
 			s.next();
 			const expr = parseExpr(s, false);
-			return NODE('subAssign', { dest, expr }, loc, s.getPos());
+			return NODE('subAssign', { dest, expr }, startPos, s.getPos());
 		}
 		default: {
 			return;

--- a/src/parser/syntaxes/statements.ts
+++ b/src/parser/syntaxes/statements.ts
@@ -14,7 +14,7 @@ import type { ITokenStream } from '../streams/token-stream.js';
  * ```
 */
 export function parseStatement(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 
 	switch (s.getKind()) {
 		case TokenKind.VarKeyword:
@@ -53,11 +53,11 @@ export function parseStatement(s: ITokenStream): Ast.Node {
 		}
 		case TokenKind.BreakKeyword: {
 			s.next();
-			return NODE('break', {}, startPos, s.token.loc);
+			return NODE('break', {}, startPos, s.getPos());
 		}
 		case TokenKind.ContinueKeyword: {
 			s.next();
-			return NODE('continue', {}, startPos, s.token.loc);
+			return NODE('continue', {}, startPos, s.getPos());
 		}
 	}
 	const expr = parseExpr(s, false);
@@ -78,7 +78,7 @@ export function parseDefStatement(s: ITokenStream): Ast.Node {
 			return parseFnDef(s);
 		}
 		default: {
-			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[s.getKind()]}`, s.token.loc);
+			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[s.getKind()]}`, s.getPos());
 		}
 	}
 }
@@ -90,9 +90,9 @@ export function parseDefStatement(s: ITokenStream): Ast.Node {
 */
 export function parseBlockOrStatement(s: ITokenStream): Ast.Node {
 	if (s.getKind() === TokenKind.OpenBrace) {
-		const startPos = s.token.loc;
+		const startPos = s.getPos();
 		const statements = parseBlock(s);
-		return NODE('block', { statements }, startPos, s.token.loc);
+		return NODE('block', { statements }, startPos, s.getPos());
 	} else {
 		return parseStatement(s);
 	}
@@ -104,7 +104,7 @@ export function parseBlockOrStatement(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseVarDef(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 
 	let mut;
 	switch (s.getKind()) {
@@ -117,7 +117,7 @@ function parseVarDef(s: ITokenStream): Ast.Node {
 			break;
 		}
 		default: {
-			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[s.getKind()]}`, s.token.loc);
+			throw new AiScriptSyntaxError(`unexpected token: ${TokenKind[s.getKind()]}`, s.getPos());
 		}
 	}
 	s.next();
@@ -140,7 +140,7 @@ function parseVarDef(s: ITokenStream): Ast.Node {
 
 	const expr = parseExpr(s, false);
 
-	return NODE('def', { name, varType: type, expr, mut, attr: [] }, startPos, s.token.loc);
+	return NODE('def', { name, varType: type, expr, mut, attr: [] }, startPos, s.getPos());
 }
 
 /**
@@ -149,7 +149,7 @@ function parseVarDef(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseFnDef(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 
 	s.nextWith(TokenKind.At);
 
@@ -167,7 +167,7 @@ function parseFnDef(s: ITokenStream): Ast.Node {
 
 	const body = parseBlock(s);
 
-	const endPos = s.token.loc;
+	const endPos = s.getPos();
 
 	return NODE('def', {
 		name,
@@ -187,12 +187,12 @@ function parseFnDef(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseOut(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 
 	s.nextWith(TokenKind.Out);
 	const expr = parseExpr(s, false);
 
-	return CALL_NODE('print', [expr], startPos, s.token.loc);
+	return CALL_NODE('print', [expr], startPos, s.getPos());
 }
 
 /**
@@ -202,7 +202,7 @@ function parseOut(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseEach(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 	let hasParen = false;
 
 	s.nextWith(TokenKind.EachKeyword);
@@ -221,7 +221,7 @@ function parseEach(s: ITokenStream): Ast.Node {
 	if (s.getKind() === TokenKind.Comma) {
 		s.next();
 	} else {
-		throw new AiScriptSyntaxError('separator expected', s.token.loc);
+		throw new AiScriptSyntaxError('separator expected', s.getPos());
 	}
 
 	const items = parseExpr(s, false);
@@ -236,11 +236,11 @@ function parseEach(s: ITokenStream): Ast.Node {
 		var: name,
 		items: items,
 		for: body,
-	}, startPos, s.token.loc);
+	}, startPos, s.getPos());
 }
 
 function parseFor(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 	let hasParen = false;
 
 	s.nextWith(TokenKind.ForKeyword);
@@ -254,7 +254,7 @@ function parseFor(s: ITokenStream): Ast.Node {
 		// range syntax
 		s.next();
 
-		const identPos = s.token.loc;
+		const identPos = s.getPos();
 
 		s.expect(TokenKind.Identifier);
 		const name = s.token.value!;
@@ -271,7 +271,7 @@ function parseFor(s: ITokenStream): Ast.Node {
 		if (s.getKind() === TokenKind.Comma) {
 			s.next();
 		} else {
-			throw new AiScriptSyntaxError('separator expected', s.token.loc);
+			throw new AiScriptSyntaxError('separator expected', s.getPos());
 		}
 
 		const to = parseExpr(s, false);
@@ -287,7 +287,7 @@ function parseFor(s: ITokenStream): Ast.Node {
 			from: _from,
 			to,
 			for: body,
-		}, startPos, s.token.loc);
+		}, startPos, s.getPos());
 	} else {
 		// times syntax
 
@@ -302,7 +302,7 @@ function parseFor(s: ITokenStream): Ast.Node {
 		return NODE('for', {
 			times,
 			for: body,
-		}, startPos, s.token.loc);
+		}, startPos, s.getPos());
 	}
 }
 
@@ -312,12 +312,12 @@ function parseFor(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseReturn(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 
 	s.nextWith(TokenKind.ReturnKeyword);
 	const expr = parseExpr(s, false);
 
-	return NODE('return', { expr }, startPos, s.token.loc);
+	return NODE('return', { expr }, startPos, s.getPos());
 }
 
 /**
@@ -352,7 +352,7 @@ function parseStatementWithAttr(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseAttr(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 
 	s.nextWith(TokenKind.OpenSharpBracket);
 
@@ -364,13 +364,13 @@ function parseAttr(s: ITokenStream): Ast.Node {
 	if (s.getKind() !== TokenKind.CloseBracket) {
 		value = parseExpr(s, true);
 	} else {
-		const closePos = s.token.loc;
+		const closePos = s.getPos();
 		value = NODE('bool', { value: true }, closePos, closePos);
 	}
 
 	s.nextWith(TokenKind.CloseBracket);
 
-	return NODE('attr', { name, value }, startPos, s.token.loc);
+	return NODE('attr', { name, value }, startPos, s.getPos());
 }
 
 /**
@@ -379,12 +379,12 @@ function parseAttr(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseLoop(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 
 	s.nextWith(TokenKind.LoopKeyword);
 	const statements = parseBlock(s);
 
-	return NODE('loop', { statements }, startPos, s.token.loc);
+	return NODE('loop', { statements }, startPos, s.getPos());
 }
 
 /**
@@ -393,13 +393,13 @@ function parseLoop(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseDoWhile(s: ITokenStream): Ast.Node {
-	const doStartPos = s.token.loc;
+	const doStartPos = s.getPos();
 	s.nextWith(TokenKind.DoKeyword);
 	const body = parseBlockOrStatement(s);
-	const whilePos = s.token.loc;
+	const whilePos = s.getPos();
 	s.nextWith(TokenKind.WhileKeyword);
 	const cond = parseExpr(s, false);
-	const endPos = s.token.loc;
+	const endPos = s.getPos();
 
 	return NODE('loop', {
 		statements: [
@@ -419,10 +419,10 @@ function parseDoWhile(s: ITokenStream): Ast.Node {
  * ```
 */
 function parseWhile(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 	s.nextWith(TokenKind.WhileKeyword);
 	const cond = parseExpr(s, false);
-	const condEndPos = s.token.loc;
+	const condEndPos = s.getPos();
 	const body = parseBlockOrStatement(s);
 
 	return NODE('loop', {
@@ -434,7 +434,7 @@ function parseWhile(s: ITokenStream): Ast.Node {
 			}, startPos, condEndPos),
 			body,
 		],
-	}, startPos, s.token.loc);
+	}, startPos, s.getPos());
 }
 
 /**
@@ -443,24 +443,24 @@ function parseWhile(s: ITokenStream): Ast.Node {
  * ```
 */
 function tryParseAssign(s: ITokenStream, dest: Ast.Node): Ast.Node | undefined {
-	const loc = s.token.loc;
+	const loc = s.getPos();
 
 	// Assign
 	switch (s.getKind()) {
 		case TokenKind.Eq: {
 			s.next();
 			const expr = parseExpr(s, false);
-			return NODE('assign', { dest, expr }, loc, s.token.loc);
+			return NODE('assign', { dest, expr }, loc, s.getPos());
 		}
 		case TokenKind.PlusEq: {
 			s.next();
 			const expr = parseExpr(s, false);
-			return NODE('addAssign', { dest, expr }, loc, s.token.loc);
+			return NODE('addAssign', { dest, expr }, loc, s.getPos());
 		}
 		case TokenKind.MinusEq: {
 			s.next();
 			const expr = parseExpr(s, false);
-			return NODE('subAssign', { dest, expr }, loc, s.token.loc);
+			return NODE('subAssign', { dest, expr }, loc, s.getPos());
 		}
 		default: {
 			return;

--- a/src/parser/syntaxes/toplevel.ts
+++ b/src/parser/syntaxes/toplevel.ts
@@ -62,7 +62,7 @@ export function parseTopLevel(s: ITokenStream): Ast.Node[] {
  * ```
 */
 export function parseNamespace(s: ITokenStream): Ast.Node {
-	const loc = s.token.loc;
+	const startPos = s.token.loc;
 
 	s.nextWith(TokenKind.Colon2);
 
@@ -110,7 +110,7 @@ export function parseNamespace(s: ITokenStream): Ast.Node {
 	}
 	s.nextWith(TokenKind.CloseBrace);
 
-	return NODE('ns', { name, members }, loc);
+	return NODE('ns', { name, members }, startPos, s.token.loc);
 }
 
 /**
@@ -119,7 +119,7 @@ export function parseNamespace(s: ITokenStream): Ast.Node {
  * ```
 */
 export function parseMeta(s: ITokenStream): Ast.Node {
-	const loc = s.token.loc;
+	const startPos = s.token.loc;
 
 	s.nextWith(TokenKind.Sharp3);
 
@@ -131,5 +131,5 @@ export function parseMeta(s: ITokenStream): Ast.Node {
 
 	const value = parseExpr(s, true);
 
-	return NODE('meta', { name, value }, loc);
+	return NODE('meta', { name, value }, startPos, value.loc.end);
 }

--- a/src/parser/syntaxes/toplevel.ts
+++ b/src/parser/syntaxes/toplevel.ts
@@ -48,7 +48,7 @@ export function parseTopLevel(s: ITokenStream): Ast.Node[] {
 				break;
 			}
 			default: {
-				throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.', s.token.loc);
+				throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.', s.getPos());
 			}
 		}
 	}
@@ -62,7 +62,7 @@ export function parseTopLevel(s: ITokenStream): Ast.Node[] {
  * ```
 */
 export function parseNamespace(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 
 	s.nextWith(TokenKind.Colon2);
 
@@ -104,13 +104,13 @@ export function parseNamespace(s: ITokenStream): Ast.Node {
 				break;
 			}
 			default: {
-				throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.', s.token.loc);
+				throw new AiScriptSyntaxError('Multiple statements cannot be placed on a single line.', s.getPos());
 			}
 		}
 	}
 	s.nextWith(TokenKind.CloseBrace);
 
-	return NODE('ns', { name, members }, startPos, s.token.loc);
+	return NODE('ns', { name, members }, startPos, s.getPos());
 }
 
 /**
@@ -119,7 +119,7 @@ export function parseNamespace(s: ITokenStream): Ast.Node {
  * ```
 */
 export function parseMeta(s: ITokenStream): Ast.Node {
-	const startPos = s.token.loc;
+	const startPos = s.getPos();
 
 	s.nextWith(TokenKind.Sharp3);
 

--- a/src/parser/token.ts
+++ b/src/parser/token.ts
@@ -109,12 +109,12 @@ export enum TokenKind {
 	CloseBrace,
 }
 
-export type TokenLocation = { column: number, line: number };
+export type TokenPosition = { column: number, line: number };
 
 export class Token {
 	constructor(
 		public kind: TokenKind,
-		public pos: TokenLocation,
+		public pos: TokenPosition,
 		public hasLeftSpacing = false,
 		/** for number literal, string literal */
 		public value?: string,
@@ -127,6 +127,6 @@ export class Token {
  * - opts.value: for number literal, string literal
  * - opts.children: for template syntax
 */
-export function TOKEN(kind: TokenKind, loc: TokenLocation, opts?: { hasLeftSpacing?: boolean, value?: Token['value'], children?: Token['children'] }): Token {
-	return new Token(kind, loc, opts?.hasLeftSpacing, opts?.value, opts?.children);
+export function TOKEN(kind: TokenKind, pos: TokenPosition, opts?: { hasLeftSpacing?: boolean, value?: Token['value'], children?: Token['children'] }): Token {
+	return new Token(kind, pos, opts?.hasLeftSpacing, opts?.value, opts?.children);
 }

--- a/src/parser/token.ts
+++ b/src/parser/token.ts
@@ -114,7 +114,7 @@ export type TokenLocation = { column: number, line: number };
 export class Token {
 	constructor(
 		public kind: TokenKind,
-		public loc: { column: number, line: number },
+		public pos: TokenLocation,
 		public hasLeftSpacing = false,
 		/** for number literal, string literal */
 		public value?: string,

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -1,19 +1,20 @@
 import type * as Ast from '../node.js';
 
-export function NODE(type: string, params: Record<string, any>, loc: { column: number, line: number }): Ast.Node {
+export function NODE(type: string, params: Record<string, any>, start: Ast.Pos, end: Ast.Pos): Ast.Node {
 	const node: Record<string, any> = { type };
 	for (const key of Object.keys(params)) {
 		if (params[key] !== undefined) {
 			node[key] = params[key];
 		}
 	}
-	node.loc = loc;
+	node.loc = { start, end };
 	return node as Ast.Node;
 }
 
-export function CALL_NODE(name: string, args: Ast.Node[], loc: { column: number, line: number }): Ast.Node {
+export function CALL_NODE(name: string, args: Ast.Node[], start: Ast.Pos, end: Ast.Pos): Ast.Node {
 	return NODE('call', {
-		target: NODE('identifier', { name }, loc),
+		// 糖衣構文はidentifierがソースコードに出現しないので長さ0とする。
+		target: NODE('identifier', { name }, start, start),
 		args,
-	}, loc);
+	}, start, end);
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -151,7 +151,7 @@ export function getTypeBySource(typeSource: Ast.TypeSource): Type {
 				return T_GENERIC(typeSource.name, [innerType]);
 			}
 		}
-		throw new AiScriptSyntaxError(`Unknown type: '${getTypeNameBySource(typeSource)}'`, typeSource.loc);
+		throw new AiScriptSyntaxError(`Unknown type: '${getTypeNameBySource(typeSource)}'`, typeSource.loc.start);
 	} else {
 		const argTypes = typeSource.args.map(arg => getTypeBySource(arg));
 		return T_FN(argTypes, getTypeBySource(typeSource.result));

--- a/test/index.ts
+++ b/test/index.ts
@@ -928,7 +928,10 @@ describe('Location', () => {
 		assert.equal(nodes.length, 1);
 		node = nodes[0];
 		if (!node.loc) assert.fail();
-		assert.deepEqual(node.loc, { line: 2, column: 4 });
+		assert.deepEqual(node.loc, {
+			start: { line: 2, column: 4 },
+			end: { line: 2, column: 15 },
+		});
 	});
 	test.concurrent('comment', async () => {
 		let node: Ast.Node;
@@ -942,7 +945,7 @@ describe('Location', () => {
 		assert.equal(nodes.length, 1);
 		node = nodes[0];
 		if (!node.loc) assert.fail();
-		assert.deepEqual(node.loc, { line: 5, column: 3 });
+		assert.deepEqual(node.loc.start, { line: 5, column: 3 });
 	});
 });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -947,6 +947,34 @@ describe('Location', () => {
 		if (!node.loc) assert.fail();
 		assert.deepEqual(node.loc.start, { line: 5, column: 3 });
 	});
+	test.concurrent('template', async () => {
+		let node: Ast.Node;
+		const parser = new Parser();
+		const nodes = parser.parse(`
+			\`hoge{1}fuga\`
+		`);
+		assert.equal(nodes.length, 1);
+		node = nodes[0];
+		if (!node.loc || node.type !== "tmpl") assert.fail();
+		assert.deepEqual(node.loc, {
+			start: { line: 2, column: 4 },
+			end: { line: 2, column: 17 },
+		});
+		assert.equal(node.tmpl.length, 3);
+		const [elem1, elem2, elem3] = node.tmpl as Ast.Expression[];
+		assert.deepEqual(elem1.loc, {
+			start: { line: 2, column: 4 },
+			end: { line: 2, column: 10 },
+		});
+		assert.deepEqual(elem2.loc, {
+			start: { line: 2, column: 10 },
+			end: { line: 2, column: 11 },
+		});
+		assert.deepEqual(elem3.loc, {
+			start: { line: 2, column: 11 },
+			end: { line: 2, column: 17 },
+		});
+	});
 });
 
 describe('Unicode', () => {

--- a/test/interpreter.ts
+++ b/test/interpreter.ts
@@ -66,7 +66,7 @@ describe('error handler', () => {
 });
 
 describe('error location', () => {
-	const exeAndGetErrLoc = (src: string): Promise<Ast.Pos|undefined> => new Promise((ok, ng) => {
+	const exeAndGetErrPos = (src: string): Promise<Ast.Pos|undefined> => new Promise((ok, ng) => {
 		const aiscript = new Interpreter({
 			emitError: FN_NATIVE((_args, _opts) => {
 				throw Error('emitError');
@@ -78,14 +78,14 @@ describe('error location', () => {
 	});
 
 	test.concurrent('Non-aiscript Error', async () => {
-		return expect(exeAndGetErrLoc(`/* (の位置
+		return expect(exeAndGetErrPos(`/* (の位置
 			*/
 			emitError()
 		`)).resolves.toEqual({ line: 3, column: 13});
 	});
 
 	test.concurrent('No "var" in namespace declaration', async () => {
-		return expect(exeAndGetErrLoc(`// vの位置
+		return expect(exeAndGetErrPos(`// vの位置
 			:: Ai {
 				let chan = 'kawaii'
 				var kun = '!?'
@@ -94,14 +94,14 @@ describe('error location', () => {
 	});
 
 	test.concurrent('Index out of range', async () => {
-		return expect(exeAndGetErrLoc(`// [の位置
+		return expect(exeAndGetErrPos(`// [の位置
 			let arr = []
 			arr[0]
 		`)).resolves.toEqual({ line: 3, column: 7});
 	});
 
 	test.concurrent('Error in passed function', async () => {
-		return expect(exeAndGetErrLoc(`// /の位置
+		return expect(exeAndGetErrPos(`// /の位置
 			[0, 1, 2].map(@(v){
 				0/v
 			})
@@ -109,7 +109,7 @@ describe('error location', () => {
 	});
 
 	test.concurrent('No such prop', async () => {
-		return expect(exeAndGetErrLoc(`// .の位置
+		return expect(exeAndGetErrPos(`// .の位置
 			[].ai
 		`)).resolves.toEqual({ line: 2, column: 6});
 	});

--- a/test/interpreter.ts
+++ b/test/interpreter.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import { expect, test } from '@jest/globals';
-import { Parser, Interpreter, values, errors, utils } from '../src';
+import { Parser, Interpreter, values, errors, utils, Ast } from '../src';
+
 let { FN_NATIVE } = values;
 let { AiScriptRuntimeError, AiScriptIndexOutOfRangeError } = errors;
 
@@ -65,13 +66,13 @@ describe('error handler', () => {
 });
 
 describe('error location', () => {
-	const exeAndGetErrLoc = (src: string): Promise<Loc|undefined> => new Promise((ok, ng) => {
+	const exeAndGetErrLoc = (src: string): Promise<Ast.Pos|undefined> => new Promise((ok, ng) => {
 		const aiscript = new Interpreter({
 			emitError: FN_NATIVE((_args, _opts) => {
 				throw Error('emitError');
 			}),
 		}, {
-			err(e) { ok(e.loc) },
+			err(e) { ok(e.pos) },
 		});
 		aiscript.exec(Parser.parse(src)).then(() => ng('error has not occured.'));
 	});

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { Scanner } from '../src/parser/scanner';
-import { TOKEN, TokenKind, TokenLocation } from '../src/parser/token';
+import { TOKEN, TokenKind, TokenPosition } from '../src/parser/token';
 import { CharStream } from '../src/parser/streams/char-stream';
 
 describe('CharStream', () => {
@@ -77,8 +77,8 @@ describe('Scanner', () => {
 		const stream = new Scanner(source);
 		return stream;
 	}
-	function next(stream: Scanner, kind: TokenKind, loc: TokenLocation, opts: { hasLeftSpacing?: boolean, value?: string }) {
-		assert.deepStrictEqual(stream.token, TOKEN(kind, loc, opts));
+	function next(stream: Scanner, kind: TokenKind, pos: TokenPosition, opts: { hasLeftSpacing?: boolean, value?: string }) {
+		assert.deepStrictEqual(stream.token, TOKEN(kind, pos, opts));
 		stream.next();
 	}
 


### PR DESCRIPTION

# What

- Loc型を変更して各ノードのlocへ終了位置を追加
- トークンとエラーが位置情報を持つプロパティーをposに変更

# Why

#722

# Additional info (optional)

- テンプレート構文でlocを取得するのに若干ハックをしている（ScannerのreadTemplateとparseAtomのTokenKind.Template）
- parsePrefixで子ノードの終了位置をprefixノードの終了位置としたが、これだとparsePostfix, parseCallと一貫性がない
  （Postfixのほうは子ノードの開始位置を使用するとエラーの位置が変わるので使用していない）
