### PR TITLE
fix: 宣言での分割代入の修正

### DIFF
--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -205,7 +205,7 @@ export class Interpreter {
 					}
 
 					const value = await this._eval(node.expr, nsScope);
-					this.define(nsScope, node.dest, value, node.mut);
+					await this.define(nsScope, node.dest, value, node.mut);
 
 					break;
 				}
@@ -396,7 +396,7 @@ export class Interpreter {
 					}
 					value.attr = attrs;
 				}
-				this.define(scope, node.dest, value, node.mut);
+				await this.define(scope, node.dest, value, node.mut);
 				return NULL;
 			}
 

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -724,7 +724,7 @@ export class Interpreter {
 	}
 
 	@autobind
-	private async define(scope: Scope, dest: Ast.Expression, value: Value, isMutable: boolean): Promise<void> {
+	private define(scope: Scope, dest: Ast.Expression, value: Value, isMutable: boolean): void {
 		switch (dest.type) {
 			case 'identifier': {
 				scope.add(dest.name, { isMutable, value });
@@ -732,16 +732,16 @@ export class Interpreter {
 			}
 			case 'arr': {
 				assertArray(value);
-				await Promise.all(dest.value.map(
-					(item, index) => this.define(scope, item, value.value[index] ?? NULL, isMutable),
-				));
+				for (const [index, item] of dest.value.entries()) {
+					this.define(scope, item, value.value[index] ?? NULL, isMutable);
+				}
 				break;
 			}
 			case 'obj': {
 				assertObject(value);
-				await Promise.all([...dest.value].map(
-					([key, item]) => this.define(scope, item, value.value.get(key) ?? NULL, isMutable),
-				));
+				for (const [key, item] of dest.value) {
+					this.define(scope, item, value.value.get(key) ?? NULL, isMutable);
+				}
 				break;
 			}
 			default: {

--- a/src/parser/plugins/validate-keyword.ts
+++ b/src/parser/plugins/validate-keyword.ts
@@ -56,15 +56,33 @@ function throwReservedWordError(name: string, loc: Ast.Loc): void {
 	throw new AiScriptSyntaxError(`Reserved word "${name}" cannot be used as variable name.`, loc.start);
 }
 
+function validateDest(node: Ast.Node): Ast.Node {
+	return visitNode(node, node => {
+		switch (node.type) {
+			case 'null': {
+				throwReservedWordError(node.type, node.loc);
+				break;
+			}
+			case 'bool': {
+				throwReservedWordError(`${node.value}`, node.loc);
+				break;
+			}
+			case 'identifier': {
+				if (reservedWord.includes(node.name)) {
+					throwReservedWordError(node.name, node.loc);
+				}
+				break;
+			}
+		}
+
+		return node;
+	});
+}
+
 function validateNode(node: Ast.Node): Ast.Node {
 	switch (node.type) {
 		case 'def': {
-			visitNode(node, node => {
-				if (node.type === 'identifier' && reservedWord.includes(node.name)) {
-					throwReservedWordError(node.name, node.loc);
-				}
-				return node;
-			});
+			validateDest(node.dest);
 			break;
 		}
 		case 'ns':

--- a/src/parser/syntaxes/statements.ts
+++ b/src/parser/syntaxes/statements.ts
@@ -100,7 +100,7 @@ export function parseBlockOrStatement(s: ITokenStream): Ast.Statement | Ast.Expr
 
 /**
  * ```abnf
- * VarDef = ("let" / "var") IDENT [":" Type] "=" Expr
+ * VarDef = ("let" / "var") (IDENT / Expr) [":" Type] "=" Expr
  * ```
 */
 function parseVarDef(s: ITokenStream): Ast.Definition {
@@ -123,7 +123,7 @@ function parseVarDef(s: ITokenStream): Ast.Definition {
 	s.next();
 
 	let dest: Ast.Expression;
-	// 全部parseExprに任せるとparseReferenceが型注釈を巻き込んでしまうためIdentifierのみ個別に処理。
+	// 全部parseExprに任せるとparseReferenceが型注釈を巻き込んでパースしてしまうためIdentifierのみ個別に処理。
 	if (s.is(TokenKind.Identifier)) {
 		const nameStartPos = s.getPos();
 		const name = s.getTokenValue();


### PR DESCRIPTION
# What

validateKeywordでnull, true, falseがエラーになるように修正

# Why

Fix #773

# Additional info (optional)

キーワードのテストは https://github.com/aiscript-dev/aiscript/pull/678#issuecomment-2132139502 とのことで変えていません。
