### PR TITLE
Obj:pickを追加

### DIFF
--- a/src/interpreter/lib/std.ts
+++ b/src/interpreter/lib/std.ts
@@ -621,23 +621,13 @@ export const std: Record<string, Value> = {
 		return OBJ(new Map([...a.value, ...b.value]));
 	}),
 
-	'Obj:extract': FN_NATIVE(([obj, keys]) => {
+	'Obj:pick': FN_NATIVE(([obj, keys]) => {
 		assertObject(obj);
 		assertArray(keys);
 		return OBJ(new Map(
 			keys.value.map(key => {
 				assertString(key);
 				return [key.value, obj.value.get(key.value) ?? NULL];
-			})
-		));
-	}),
-
-	'Obj:extract_with_default': FN_NATIVE(([obj, defaults]) => {
-		assertObject(obj);
-		assertObject(defaults);
-		return OBJ(new Map(
-			[...defaults.value].map(([key, def]) => {
-				return [key, obj.value.get(key) ?? def];
 			})
 		));
 	}),

--- a/src/interpreter/lib/std.ts
+++ b/src/interpreter/lib/std.ts
@@ -620,6 +620,27 @@ export const std: Record<string, Value> = {
 		assertObject(b);
 		return OBJ(new Map([...a.value, ...b.value]));
 	}),
+
+	'Obj:extract': FN_NATIVE(([obj, keys]) => {
+		assertObject(obj);
+		assertArray(keys);
+		return OBJ(new Map(
+			keys.value.map(key => {
+				assertString(key);
+				return [key.value, obj.value.get(key.value) ?? NULL];
+			})
+		));
+	}),
+
+	'Obj:extract_with_default': FN_NATIVE(([obj, defaults]) => {
+		assertObject(obj);
+		assertObject(defaults);
+		return OBJ(new Map(
+			[...defaults.value].map(([key, def]) => {
+				return [key, obj.value.get(key) ?? def];
+			})
+		));
+	}),
 	//#endregion
 	
 	//#region Error

--- a/test/std.ts
+++ b/test/std.ts
@@ -200,23 +200,13 @@ describe('Obj', () => {
 		eq(res, utils.jsToVal({ a: 1, b: 3, c: 4}));
 	});
 
-	test.concurrent('extract', async () => {
+	test.concurrent('pick', async () => {
 		const res = await exe(`
 		let o = { a: 1, b: 2, c: 3 }
 
-		<: Obj:extract(o, ['b', 'd'])
+		<: Obj:pick(o, ['b', 'd'])
 		`);
 		eq(res, utils.jsToVal({ b: 2, d: null }));
-	});
-
-	test.concurrent('extract_with_default', async () => {
-		const res = await exe(`
-		let o = { a: 1, b: 2, c: 3 }
-		let d = { b: 4, d: 5 }
-
-		<: Obj:extract_with_default(o, d)
-		`);
-		eq(res, utils.jsToVal({ b: 2, d: 5 }));
 	});
 });
 

--- a/test/std.ts
+++ b/test/std.ts
@@ -199,6 +199,25 @@ describe('Obj', () => {
 		`);
 		eq(res, utils.jsToVal({ a: 1, b: 3, c: 4}));
 	});
+
+	test.concurrent('extract', async () => {
+		const res = await exe(`
+		let o = { a: 1, b: 2, c: 3 }
+
+		<: Obj:extract(o, ['b', 'd'])
+		`);
+		eq(res, utils.jsToVal({ b: 2, d: null }));
+	});
+
+	test.concurrent('extract_with_default', async () => {
+		const res = await exe(`
+		let o = { a: 1, b: 2, c: 3 }
+		let d = { b: 4, d: 5 }
+
+		<: Obj:extract_with_default(o, d)
+		`);
+		eq(res, utils.jsToVal({ b: 2, d: 5 }));
+	});
 });
 
 describe('Str', () => {

--- a/unreleased/obj-extract
+++ b/unreleased/obj-extract
@@ -1,1 +1,1 @@
-- 関数`Obj:extract`を追加
+- 関数`Obj:pick`を追加

--- a/unreleased/obj-extract
+++ b/unreleased/obj-extract
@@ -1,1 +1,1 @@
-- `Obj:extract`と`Obj:extract_with_default`を追加
+- 関数`Obj:extract`を追加

--- a/unreleased/obj-extract
+++ b/unreleased/obj-extract
@@ -1,0 +1,1 @@
+- `Obj:extract`と`Obj:extract_with_default`を追加


### PR DESCRIPTION
関数~~Obj:extractとObj:extract_with_default~~`Obj:pick`を追加します。

## doc
#### @Obj:pick&lt;T&gt;(_o_: obj&lt;T&gt;, _keys_: arr&lt;str&gt;): obj&lt;T&gt;
オブジェクト`o`のプロパティのうち、キー名が`keys`に含まれるもののみを抽出します。  
`keys`にあって`o`にないキーは`NULL`になります。