### PR TITLE
1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 [Read translated version (en)](./translations/en/CHANGELOG.md)
 
+# 1.0.1
+
+- Fix: `Math:gen_rng`のアルゴリズム`chacha20`および`rc4`が非セキュアコンテクスト下では動作しないため、そのような環境下では`options.algorithm`のデフォルトを`rc4_legacy`に変更
+
 # 1.0.0
 
 - 新しいAiScriptパーサーを実装

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "@syuilo/aiscript",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "AiScript implementation",
 	"author": "syuilo <syuilotan@yahoo.co.jp>",
 	"license": "MIT",

--- a/unreleased/fix-gen_rng-default.md
+++ b/unreleased/fix-gen_rng-default.md
@@ -1,0 +1,1 @@
+- Fix: `Math:gen_rng`のアルゴリズム`chacha20`および`rc4`が非セキュアコンテクスト下では動作しないため、そのような環境下では`options.algorithm`のデフォルトを`rc4_legacy`に変更

--- a/unreleased/fix-gen_rng-default.md
+++ b/unreleased/fix-gen_rng-default.md
@@ -1,1 +1,0 @@
-- Fix: `Math:gen_rng`のアルゴリズム`chacha20`および`rc4`が非セキュアコンテクスト下では動作しないため、そのような環境下では`options.algorithm`のデフォルトを`rc4_legacy`に変更


### PR DESCRIPTION
- Fix: `Math:gen_rng`のアルゴリズム`chacha20`および`rc4`が非セキュアコンテクスト下では動作しないため、そのような環境下では`options.algorithm`のデフォルトを`rc4_legacy`に変更

こちらのPRは[#958のTODO](https://github.com/aiscript-dev/aiscript/issues/958#issuecomment-3193585760)の２番目まで行ったものです。 @syuilo さんが`publish`を行った後、masterにマージされます。